### PR TITLE
update noexec linter script with better output

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -13,7 +13,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run ShellCheck
         run: |
-          find . -type f -name '*.sh' | xargs -n 1 sh -n
+          for file in $(find . -type f -name '*.sh'); do
+            echo "::group::${file}"
+            echo "Checking ${file}"
+            sh -n "${file}"
+            echo "::endgroup::"
+          done
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the `lint-shell.yml` workflow to improve the organization and visibility of shell script checks. The changes include using a `for` loop instead of `xargs` to run `sh -n` on each shell script file individually, and adding `::group::` and `::endgroup::` blocks to group the output of each file being checked.

Main changes:

* <a href="diffhunk://#diff-cb01ce593de6f1d1a9c247dde8298db8c7210be7d0654e00597dd13c8e0e565eL16-R21">`.github/workflows/lint-shell.yml`</a>: Updated the `lint-shell.yml` workflow to improve organization and visibility of shell script checks.