### PR TITLE
Add SonarCloud workflow for continuous code quality analysis

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,19 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarqube:
+    name: SonarQube
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@aa494459d7c39c106cc77b166de8b4250a32bb97 # v5.1.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=Klintrup_check_gmirror
+sonar.organization=klintrup
+
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=check_gmirror
+#sonar.projectVersion=1.0
+
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for SonarQube analysis. The main changes include setting up the workflow to run on specific events and configuring the necessary steps for the SonarQube scan.

### New GitHub Actions workflow for SonarQube analysis:

* [`.github/workflows/sonarcloud.yml`](diffhunk://#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bceR1-R19): Added a new workflow named `Build` that triggers on `push` to the `main` branch and on pull request events (`opened`, `synchronize`, `reopened`). The workflow includes a job named `SonarQube` that runs on `ubuntu-latest` and performs a SonarQube scan using the `SonarSource/sonarqube-scan-action`.